### PR TITLE
Support XCMS 4 feature_id column

### DIFF
--- a/bin/scripts/xcms_formatter.py
+++ b/bin/scripts/xcms_formatter.py
@@ -16,6 +16,12 @@ def convert_to_feature_csv(input_filename, output_filename):
 
     input_format_df = pd.read_csv(input_filename,index_col=None,sep='\t')
 
+    # xcms 4 (jorainer/xcms-gnps-tools customFunctions.R) writes the feature
+    # identifier column as `feature_id` instead of `Row.names` as the
+    # xcms 3 era export (DorresteinLaboratory/XCMS3_FeatureBasedMN) did.
+    if 'feature_id' in input_format_df.columns and 'Row.names' not in input_format_df.columns:
+        input_format_df = input_format_df.rename(columns={'feature_id': 'Row.names'})
+
     if 'annotation network number' not in input_format_df.columns:
         #Prepare left table with ID mz rt
         input_format_df = input_format_df.rename(columns={ "Row.names":"row ID", "mzmed":"row m/z","rtmed":"row retention time"})

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: feature_based_molecular_networking_workflow
 workflowdescription: feature_based_molecular_networking_workflow
 workflowlongdescription: This is a feature_based_molecular_networking_workflow workflow for GNPS2
-workflowversion: "2026.03.19"
+workflowversion: "2026.05.28"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false
@@ -62,7 +62,7 @@ parameterlist:
         - value: PROGENESIS
           display: PROGENESIS
         - value: XCMS3
-          display: XCMS3
+          display: XCMS 3 or 4
         - value: METABOSCAPE
           display: METABOSCAPE
         - value: MSDIAL


### PR DESCRIPTION
XCMS 4 (jorainer/xcms-gnps-tools customFunctions.R) names the feature identifier column `feature_id`; XCMS 3 (DorresteinLaboratory/XCMS3_FeatureBasedMN) named it `Row.names`. Alias `feature_id` to `Row.names` so the existing formatter path handles both, and relabel the input option to "XCMS 3 or 4" (value unchanged).