### PR TITLE
feat: add MassCube input mode to FBMN workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.env
 *credentials
 *__pycache__*
+conda_env/

--- a/bin/scripts/masscube_formatter.py
+++ b/bin/scripts/masscube_formatter.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on 2026-06-01
+
+@purpose: convert MassCube aligned feature table + MSP spectra into the
+          GNPS-standard quantification CSV and MGF consumed by FBMN.
+"""
+import sys
+import pandas as pd
+
+# In a MassCube aligned feature table, columns up to and including
+# "database" are metadata; every column after it is a per-sample intensity.
+LAST_METADATA_COLUMN = "database"
+DEFAULT_METADATA_COLUMN_COUNT = 30
+
+
+def convert_to_feature_csv(input_filename, output_filename):
+    df = pd.read_csv(input_filename, sep="\t")
+    columns = list(df.columns)
+
+    if LAST_METADATA_COLUMN in columns:
+        boundary = columns.index(LAST_METADATA_COLUMN) + 1
+    else:
+        print("Warning: '{}' column not found; falling back to fixed metadata "
+              "column count {}".format(LAST_METADATA_COLUMN,
+                                       DEFAULT_METADATA_COLUMN_COUNT))
+        boundary = DEFAULT_METADATA_COLUMN_COUNT
+
+    sample_names = columns[boundary:]
+
+    output_records = []
+    for record in df.to_dict(orient="records"):
+        output_record = {
+            "row ID": str(int(record["feature_ID"])),
+            "row m/z": str(record["m/z"]),
+            "row retention time": str(record["RT"]),
+        }
+        for sample_name in sample_names:
+            output_record[sample_name + " Peak area"] = record[sample_name]
+        output_records.append(output_record)
+
+    output_headers = ["row ID", "row m/z", "row retention time"]
+    output_headers += [sample_name + " Peak area" for sample_name in sample_names]
+
+    output_df = pd.DataFrame(output_records)
+    output_df.to_csv(output_filename, sep=",", index=False, columns=output_headers)
+    return
+
+
+def _write_block(out, scan, precursor_mz, peaks):
+    """Write one MGF block. Returns True if written, False if skipped
+    (empty spectrum or missing precursor)."""
+    if scan is None or precursor_mz is None or len(peaks) == 0:
+        return False
+    out.write("BEGIN IONS\n")
+    out.write("TITLE=SCAN={}\n".format(scan))
+    out.write("SCANS={}\n".format(scan))
+    out.write("PEPMASS={}\n".format(precursor_mz))
+    for mz, intensity in peaks:
+        out.write("{} {}\n".format(mz, intensity))
+    out.write("END IONS\n\n")
+    return True
+
+
+def convert_mgf(input_msp, output_mgf):
+    """Convert a MassCube MSP file to MGF. One block per feature that has at
+    least one MS2 peak (Num Peaks > 0); empty spectra are skipped. SCANS is the
+    MSP ID, which equals the feature table's feature_ID / row ID."""
+    written = 0
+    scan = None
+    precursor_mz = None
+    peaks = []
+    reading_peaks = False
+
+    with open(output_mgf, "w") as out:
+        with open(input_msp) as fh:
+            for raw_line in fh:
+                line = raw_line.strip()
+
+                if line == "":
+                    # Blank line terminates a block
+                    if _write_block(out, scan, precursor_mz, peaks):
+                        written += 1
+                    scan = None
+                    precursor_mz = None
+                    peaks = []
+                    reading_peaks = False
+                    continue
+
+                if reading_peaks:
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        peaks.append((parts[0], parts[1]))
+                    continue
+
+                lower = line.lower()
+                if lower.startswith("id:"):
+                    scan = line.split(":", 1)[1].strip()
+                elif lower.startswith("precursormz:"):
+                    precursor_mz = line.split(":", 1)[1].strip()
+                elif lower.startswith("num peaks:"):
+                    reading_peaks = True
+
+        # Flush the final block if the file doesn't end with a blank line
+        if _write_block(out, scan, precursor_mz, peaks):
+            written += 1
+
+    return written
+
+
+if __name__ == "__main__":
+    convert_to_feature_csv(sys.argv[1], sys.argv[2])

--- a/bin/scripts/reformat_quantification.py
+++ b/bin/scripts/reformat_quantification.py
@@ -17,6 +17,7 @@ import progenesis_formatter
 import mztabm_formatter
 import agilent_formatter
 import agilent2_formatter
+import masscube_formatter
 from agilent_explorer2_formatter import agilent_explorer2_formatter
 
 
@@ -161,6 +162,17 @@ def main():
 
         compound_filename_mapping = mztabm_formatter.convert_to_feature_csv(args.quantification_table, args.quantification_table_reformatted)
         shutil.copyfile(input_mgf, args.output_mgf)
+
+    elif args.toolname == "MASSCUBE":
+        print("MASSCUBE")
+
+        if len(input_filenames) != 1:
+            print("Must input exactly 1 spectrum msp file")
+            exit(1)
+
+        input_msp = input_filenames[0]
+        masscube_formatter.convert_to_feature_csv(args.quantification_table, args.quantification_table_reformatted)
+        masscube_formatter.convert_mgf(input_msp, args.output_mgf)
 
     # Finally, we can renormlize the output
     try:

--- a/bin/scripts/test_masscube_formatter.py
+++ b/bin/scripts/test_masscube_formatter.py
@@ -1,0 +1,74 @@
+import os
+import re
+import pandas as pd
+import masscube_formatter
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data", "MassCube_data")
+FEATURE_TABLE = os.path.join(DATA_DIR, "aligned_feature_table_before_annotation.txt")
+MSP = os.path.join(DATA_DIR, "features.msp")
+
+
+def test_feature_csv_headers_and_rows(tmp_path):
+    out = str(tmp_path / "ft.csv")
+    masscube_formatter.convert_to_feature_csv(FEATURE_TABLE, out)
+    df = pd.read_csv(out)
+
+    # First three columns are the GNPS-standard ones, in order
+    assert list(df.columns[:3]) == ["row ID", "row m/z", "row retention time"]
+
+    # Every remaining column is a per-sample "Peak area" column (13 samples)
+    peak_cols = [c for c in df.columns if c.endswith(" Peak area")]
+    assert len(peak_cols) == 13
+    assert len(df.columns) == 3 + 13
+
+    # All features are kept and row IDs are the feature IDs 1..29851
+    assert len(df) == 29851
+    assert df["row ID"].min() == 1
+    assert df["row ID"].max() == 29851
+    assert df["row ID"].is_unique
+
+    # Spot-check feature 1: m/z 306.207, RT 8.37
+    row1 = df[df["row ID"] == 1].iloc[0]
+    assert abs(row1["row m/z"] - 306.207) < 1e-3
+    assert abs(row1["row retention time"] - 8.37) < 1e-3
+
+
+def test_mgf_only_ms2_features(tmp_path):
+    out = str(tmp_path / "specs.mgf")
+    written = masscube_formatter.convert_mgf(MSP, out)
+
+    # Only MS2-bearing features (Num Peaks > 0) become MGF blocks
+    assert written == 3624
+
+    content = open(out).read()
+    assert content.count("BEGIN IONS") == 3624
+    assert content.count("END IONS") == 3624
+
+    # No empty spectra: every block carries at least one peak line
+    blocks = content.split("BEGIN IONS")[1:]
+    for block in blocks:
+        body = block.split("END IONS")[0]
+        peak_lines = [ln for ln in body.strip().splitlines()
+                      if ln and not ln.startswith(("TITLE", "SCANS", "PEPMASS"))]
+        assert len(peak_lines) >= 1
+
+
+def test_mgf_scan_pepmass_and_linkage(tmp_path):
+    mgf_out = str(tmp_path / "specs.mgf")
+    csv_out = str(tmp_path / "ft.csv")
+    masscube_formatter.convert_mgf(MSP, mgf_out)
+    masscube_formatter.convert_to_feature_csv(FEATURE_TABLE, csv_out)
+
+    content = open(mgf_out).read()
+
+    # First feature: SCANS=1 with PEPMASS 306.207
+    first_block = content.split("END IONS")[0]
+    assert "SCANS=1" in first_block
+    assert "TITLE=SCAN=1" in first_block
+    assert "PEPMASS=306.207" in first_block
+
+    # Every SCANS in the MGF exists as a row ID in the quant table
+    scans = set(int(s) for s in re.findall(r"SCANS=(\d+)", content))
+    row_ids = set(pd.read_csv(csv_out)["row ID"].tolist())
+    assert scans.issubset(row_ids)
+    assert len(scans) == 3624

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: feature_based_molecular_networking_workflow
 workflowdescription: feature_based_molecular_networking_workflow
-workflowlongdescription: This is a feature_based_molecular_networking_workflow workflow for GNPS2
-workflowversion: "2026.05.28"
+workflowlongdescription: This is a Feature Based Molecular Networking (FBMN) workflow for GNPS2. Please find the documentation <a href="https://wang-bioinformatics-lab.github.io/GNPS2_Documentation/fbmn/" target="_blank">here</a>.
+workflowversion: "2026.06.01"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false
@@ -79,6 +79,8 @@ parameterlist:
           display: AGILENT_EXPLORER2
         - value: MZTABM
           display: MAZTABM
+        - value: MASSCUBE
+          display: MASSCUBE
 
     - displayname: Additional Edges
       paramtype: section


### PR DESCRIPTION
Add masscube_formatter.py to convert a MassCube aligned feature table (feature_ID/m/z/RT + per-sample intensities) into the GNPS-standard quant CSV, and its MSP spectra into MGF. SCANS = feature_ID = row ID, so spectra link to features for free; only MS2-bearing features (Num Peaks > 0) are written to the MGF, all peaks kept.

- Wire a MASSCUBE branch into reformat_quantification.py
- Add MASSCUBE option to the Feature Finding Tool dropdown and bump workflowversion to 2026.06.01
- Add pytest coverage for the formatter (feature table, MGF, linkage)
- gitignore the local ./conda_env testing environment