### PR TITLE
feat: add Asari input mode to FBMN workflow

### DIFF
--- a/bin/scripts/reformat_quantification.py
+++ b/bin/scripts/reformat_quantification.py
@@ -36,7 +36,9 @@ def main():
     input_filenames = glob.glob(os.path.join(args.input_spectra_folder, "*"))
 
     # might be MZMINE MZMINE2 or MZMINE3 in the future
-    if "MZMINE" in args.toolname:
+    # ASARI exports a quant table and MGF already in the MZmine-style format,
+    # so it reuses the MZMINE code path.
+    if "MZMINE" in args.toolname or args.toolname == "ASARI":
         print(args.toolname)
 
         if len(input_filenames) != 1:

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -81,6 +81,8 @@ parameterlist:
           display: MAZTABM
         - value: MASSCUBE
           display: MASSCUBE
+        - value: ASARI
+          display: ASARI
 
     - displayname: Additional Edges
       paramtype: section


### PR DESCRIPTION
Asari exports a quant table and MGF already in the MZmine-style format, so it reuses the MZMINE code path in reformat_quantification.py. Adds a dedicated ASARI option to the Feature Finding Tool selector so the tool is labeled distinctly (e.g. in the mzTab output) while sharing the backend logic.