### PR TITLE
feat: add Force Offline Annotations option to FBMN library annotation

### DIFF
--- a/nf_workflow.nf
+++ b/nf_workflow.nf
@@ -51,6 +51,9 @@ params.library_min_matched_peaks = 6
 params.library_analog_search = "0"
 params.library_analog_max_shift = 1999
 
+// Force offline library annotations (speeds up workflow by avoiding API calls)
+params.forceoffline = "Yes" // Yes or No
+
 //TODO: Implement This
 params.library_filter_precursor = 1
 params.library_filter_window = 1
@@ -310,6 +313,7 @@ process librarygetGNPSAnnotations {
     input:
     path "merged_results.tsv"
     path "library_summary.tsv"
+    val forceoffline
 
     output:
     path 'merged_results_with_gnps.tsv'
@@ -318,7 +322,8 @@ process librarygetGNPSAnnotations {
     python $TOOL_FOLDER/scripts/getGNPS_library_annotations.py \
     merged_results.tsv \
     merged_results_with_gnps.tsv \
-    --librarysummary library_summary.tsv
+    --librarysummary library_summary.tsv \
+    --forceoffline $forceoffline
     """
 }
 
@@ -470,7 +475,7 @@ workflow {
     library_summary_merged_ch = library_summary_ch.collectFile(name: "library_summary.tsv", keepHeader: true)
     library_summary_merged_ch = library_summary_merged_ch.ifEmpty(file("NO_FILE"))
 
-    gnps_library_results_ch = librarygetGNPSAnnotations(merged_results_ch, library_summary_merged_ch)
+    gnps_library_results_ch = librarygetGNPSAnnotations(merged_results_ch, library_summary_merged_ch, params.forceoffline)
     gnps_library_results_ch = gnps_library_results_ch.ifEmpty(file("NO_FILE"))
 
     // Networking

--- a/nf_workflow.nf
+++ b/nf_workflow.nf
@@ -380,8 +380,6 @@ process createNetworkGraphML {
 }
 
 process summaryLibrary {
-    publishDir "$params.publishdir/nf_output", mode: 'copy'
-
     cache 'lenient'
 
     conda "$TOOL_FOLDER/conda_env.yml"

--- a/workflowinput.yaml
+++ b/workflowinput.yaml
@@ -1,7 +1,7 @@
 workflowname: feature_based_molecular_networking_workflow
 workflowdescription: feature_based_molecular_networking_workflow
 workflowlongdescription: This is a Feature Based Molecular Networking (FBMN) workflow for GNPS2. Please find the documentation <a href="https://wang-bioinformatics-lab.github.io/GNPS2_Documentation/fbmn/" target="_blank">here</a>.
-workflowversion: "2026.06.29"
+workflowversion: "2026.07.08"
 workflowfile: nf_workflow.nf
 workflowautohide: false
 adminonly: false
@@ -231,8 +231,18 @@ parameterlist:
       nf_paramname: library_topk
       formplaceholder: Enter the topk
       formvalue: "1"
-    
-    
+
+    - displayname: Force Offline Annotations (speeds up workflow)
+      paramtype: select
+      nf_paramname: forceoffline
+      formvalue: "Yes"
+      options:
+        - value: "Yes"
+          display: "Yes"
+        - value: "No"
+          display: "No"
+
+
     - displayname: Normalization Parameters
       paramtype: section
 


### PR DESCRIPTION
Port the "Force Offline Annotations" option from the Library Search workflow, using the shared getGNPS_library_annotations.py code that already supports --forceoffline. When enabled, library annotation enrichment is built from the local library summary instead of GNPS/ structure/classyfire/npclassifier API calls, speeding up the workflow.

Defaults to "Yes" to match the Library Search workflow. Also bump workflowversion to 2026.07.08.