### PR TITLE
Add ASARI raw (TSV + MSP) formatter for FBMN

### DIFF
--- a/bin/scripts/asari_formatter.py
+++ b/bin/scripts/asari_formatter.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on 2026-07-27
+
+@purpose: convert raw asari output (aligned feature-table TSV + MS/MS MSP) into
+          the GNPS-standard quantification CSV and MGF consumed by FBMN.
+
+asari ships the feature table and the MSP with no shared feature id -- the MSP
+is keyed by mass-track/cluster (track_<mz>_clus<N>), not by feature. So each
+MS/MS spectrum is matched to a feature by precursor m/z (+/- 10 ppm gate) and
+retention time (must fall inside the feature's RT bounds), with the closest RT
+winning. row ID is assigned 1..N by table position and reused as the MGF SCANS,
+so the two outputs share one numbering (the downstream FBMN join is
+cluster index == row ID == MGF SCANS).
+"""
+import sys
+import bisect
+import pandas as pd
+
+# In an asari aligned feature table, columns up to and including
+# "detection_counts" are metadata; every column after it is a per-sample
+# intensity.
+LAST_METADATA_COLUMN = "detection_counts"
+DEFAULT_METADATA_COLUMN_COUNT = 11
+
+# Precursor m/z gate for matching a spectrum to a feature.
+PPM_TOLERANCE = 10.0
+
+
+def convert_to_feature_csv(input_filename, output_filename):
+    """Write the GNPS quantification CSV and return an in-memory feature table
+    (row ID + mz + rtime + RT bounds + id_number) for the MGF matcher, so both
+    outputs share the exact same row ID assignment."""
+    df = pd.read_csv(input_filename, sep="\t")
+    df = df.reset_index(drop=True)
+    columns = list(df.columns)
+
+    if LAST_METADATA_COLUMN in columns:
+        boundary = columns.index(LAST_METADATA_COLUMN) + 1
+    else:
+        print("Warning: '{}' column not found; falling back to fixed metadata "
+              "column count {}".format(LAST_METADATA_COLUMN,
+                                       DEFAULT_METADATA_COLUMN_COUNT))
+        boundary = DEFAULT_METADATA_COLUMN_COUNT
+
+    sample_names = columns[boundary:]
+
+    # row ID 1..N by table position (no zero -- asari's native id starts at F0).
+    row_ids = list(range(1, len(df) + 1))
+
+    output_records = []
+    for row_id, record in zip(row_ids, df.to_dict(orient="records")):
+        output_record = {
+            "row ID": str(row_id),
+            "row m/z": record["mz"],
+            "row retention time": record["rtime"],
+        }
+        for sample_name in sample_names:
+            output_record[sample_name + " Peak area"] = record[sample_name]
+        output_records.append(output_record)
+
+    output_headers = ["row ID", "row m/z", "row retention time"]
+    output_headers += [sample_name + " Peak area" for sample_name in sample_names]
+
+    output_df = pd.DataFrame(output_records)
+    output_df.to_csv(output_filename, sep=",", index=False, columns=output_headers)
+
+    feature_df = pd.DataFrame({
+        "row ID": row_ids,
+        "id_number": df["id_number"].astype(str).values,
+        "mz": df["mz"].astype(float).values,
+        "rtime": df["rtime"].astype(float).values,
+        "rtime_left_base": df["rtime_left_base"].astype(float).values,
+        "rtime_right_base": df["rtime_right_base"].astype(float).values,
+    })
+    return feature_df
+
+
+def _parse_msp(input_msp):
+    """Parse an asari MSP into a list of spectra, each a dict with id,
+    precursor_mz (float), rt (float, seconds) and peaks (list of (mz, intensity)
+    strings, preserved verbatim). Empty spectra are dropped."""
+    spectra = []
+    spec_id = None
+    precursor_mz = None
+    rt = None
+    peaks = []
+    reading_peaks = False
+
+    def _flush():
+        if precursor_mz is not None and rt is not None and peaks:
+            spectra.append({
+                "id": spec_id,
+                "precursor_mz": precursor_mz,
+                "rt": rt,
+                "peaks": peaks,
+            })
+
+    with open(input_msp) as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+
+            if line == "":
+                _flush()
+                spec_id = None
+                precursor_mz = None
+                rt = None
+                peaks = []
+                reading_peaks = False
+                continue
+
+            if reading_peaks:
+                parts = line.split()
+                if len(parts) >= 2:
+                    peaks.append((parts[0], parts[1]))
+                continue
+
+            lower = line.lower()
+            if lower.startswith("id:"):
+                spec_id = line.split(":", 1)[1].strip()
+            elif lower.startswith("precursormz:"):
+                precursor_mz = float(line.split(":", 1)[1].strip())
+            elif lower.startswith("retentiontime:"):
+                rt = float(line.split(":", 1)[1].strip())
+            elif lower.startswith("num peaks:"):
+                reading_peaks = True
+
+        # Flush the final block if the file doesn't end with a blank line.
+        _flush()
+
+    return spectra
+
+
+def _match_spectra_to_features(spectra, feature_df):
+    """Assign each spectrum to its best feature (m/z +/- 10 ppm gate, RT inside
+    the feature's bounds; closest RT wins, then closest m/z), then resolve
+    collisions (2+ spectra on one feature) by the same criterion.
+
+    Returns (best_for_feature, n_unmatched):
+      best_for_feature: row_id -> (key, spectrum) where key = (rt_diff, mz_diff)
+      n_unmatched:      spectra that matched no feature at all
+    """
+    feats = feature_df.sort_values("mz").reset_index(drop=True)
+    mz_arr = feats["mz"].values
+    rtime_arr = feats["rtime"].values
+    left_arr = feats["rtime_left_base"].values
+    right_arr = feats["rtime_right_base"].values
+    row_id_arr = feats["row ID"].values
+
+    best_for_feature = {}
+    n_unmatched = 0
+
+    for spec in spectra:
+        pmz = spec["precursor_mz"]
+        rt = spec["rt"]
+
+        # Binary-search a slightly padded m/z window, then apply the exact
+        # ppm test (relative to the feature m/z) and RT-bounds test inside.
+        window = pmz * (PPM_TOLERANCE + 1.0) * 1e-6
+        lo = bisect.bisect_left(mz_arr, pmz - window)
+        hi = bisect.bisect_right(mz_arr, pmz + window)
+
+        best = None  # (rt_diff, mz_diff, row_id)
+        for j in range(lo, hi):
+            fmz = mz_arr[j]
+            if abs(fmz - pmz) / fmz * 1e6 > PPM_TOLERANCE:
+                continue
+            if not (left_arr[j] <= rt <= right_arr[j]):
+                continue
+            cand = (abs(rtime_arr[j] - rt), abs(fmz - pmz), int(row_id_arr[j]))
+            if best is None or cand < best:
+                best = cand
+
+        if best is None:
+            n_unmatched += 1
+            continue
+
+        rt_diff, mz_diff, row_id = best
+        key = (rt_diff, mz_diff)
+        prev = best_for_feature.get(row_id)
+        if prev is None or key < prev[0]:
+            best_for_feature[row_id] = (key, spec)
+
+    return best_for_feature, n_unmatched
+
+
+def convert_mgf(input_msp, output_mgf, feature_df):
+    """Match the MSP spectra to features and write one MGF block per matched
+    feature, sorted by row ID ascending (so SCANS is monotonically increasing).
+    SCANS == row ID; asari's native id_number is carried as ASARI_FEATURE_ID."""
+    spectra = _parse_msp(input_msp)
+    best_for_feature, n_unmatched = _match_spectra_to_features(spectra, feature_df)
+
+    id_by_row = dict(zip(feature_df["row ID"].astype(int),
+                         feature_df["id_number"].astype(str)))
+
+    written = 0
+    with open(output_mgf, "w") as out:
+        for row_id in sorted(best_for_feature.keys()):
+            _, spec = best_for_feature[row_id]
+            out.write("BEGIN IONS\n")
+            out.write("TITLE=SCAN={}\n".format(row_id))
+            out.write("SCANS={}\n".format(row_id))
+            out.write("PEPMASS={}\n".format(spec["precursor_mz"]))
+            out.write("RTINSECONDS={}\n".format(spec["rt"]))
+            out.write("ASARI_FEATURE_ID={}\n".format(id_by_row.get(row_id, "")))
+            for mz, intensity in spec["peaks"]:
+                out.write("{} {}\n".format(mz, intensity))
+            out.write("END IONS\n\n")
+            written += 1
+
+    matched = len(spectra) - n_unmatched
+    collision_dropped = matched - written
+    print("ASARI: {} spectra parsed | {} matched a feature | {} unmatched "
+          "(no feature) | {} dropped in collision | {} MGF blocks written".format(
+              len(spectra), matched, n_unmatched, collision_dropped, written))
+    return written
+
+
+if __name__ == "__main__":
+    # Usage: asari_formatter.py <feature_table.tsv> <out.csv> [<spectra.msp> <out.mgf>]
+    feature_df = convert_to_feature_csv(sys.argv[1], sys.argv[2])
+    if len(sys.argv) > 4:
+        convert_mgf(sys.argv[3], sys.argv[4], feature_df)

--- a/bin/scripts/reformat_quantification.py
+++ b/bin/scripts/reformat_quantification.py
@@ -18,6 +18,7 @@ import mztabm_formatter
 import agilent_formatter
 import agilent2_formatter
 import masscube_formatter
+import asari_formatter
 from agilent_explorer2_formatter import agilent_explorer2_formatter
 
 
@@ -36,11 +37,9 @@ def main():
     input_filenames = glob.glob(os.path.join(args.input_spectra_folder, "*"))
 
     # might be MZMINE MZMINE2 or MZMINE3 in the future
-    # ASARI exports a quant table and MGF already in the MZmine-style format,
-    # so it reuses the MZMINE code path.
     # EVERYTHING_BAGEL is the GNPS2 everything_bagel_workflow feature finding output,
     # which emits an MZmine2-style quant table + MGF, so it also reuses the MZMINE code path.
-    if "MZMINE" in args.toolname or args.toolname in ("ASARI", "EVERYTHING_BAGEL"):
+    if "MZMINE" in args.toolname or args.toolname in ("EVERYTHING_BAGEL",):
         print(args.toolname)
 
         if len(input_filenames) != 1:
@@ -177,6 +176,20 @@ def main():
         input_msp = input_filenames[0]
         masscube_formatter.convert_to_feature_csv(args.quantification_table, args.quantification_table_reformatted)
         masscube_formatter.convert_mgf(input_msp, args.output_mgf)
+
+    elif args.toolname == "ASARI":
+        print("ASARI")
+
+        if len(input_filenames) != 1:
+            print("Must input exactly 1 spectrum msp file")
+            exit(1)
+
+        # Raw asari output: a feature-table TSV + an MS/MS MSP with no shared
+        # feature id. asari_formatter assigns the row IDs and matches each
+        # spectrum to a feature by precursor m/z + retention time.
+        input_msp = input_filenames[0]
+        feature_df = asari_formatter.convert_to_feature_csv(args.quantification_table, args.quantification_table_reformatted)
+        asari_formatter.convert_mgf(input_msp, args.output_mgf, feature_df)
 
     # Finally, we can renormlize the output
     try:

--- a/bin/scripts/test_asari_formatter.py
+++ b/bin/scripts/test_asari_formatter.py
@@ -1,0 +1,145 @@
+import os
+import re
+import pandas as pd
+import asari_formatter
+
+DATA_DIR = os.path.join(os.path.dirname(__file__), "..", "..", "data", "Asari_Raw")
+FEATURE_TABLE = os.path.join(DATA_DIR, "full_Feature_table.tsv")
+MSP = os.path.join(DATA_DIR, "ms2_spectra.msp")
+
+
+# --------------------------------------------------------------------------
+# Synthetic tests: pin the matching *rules* independent of the real dataset.
+# --------------------------------------------------------------------------
+
+def _features(rows):
+    """rows: list of (row_id, mz, rtime, left, right)."""
+    return pd.DataFrame(
+        [{"row ID": r[0], "id_number": "F{}".format(r[0] - 1), "mz": r[1],
+          "rtime": r[2], "rtime_left_base": r[3], "rtime_right_base": r[4]}
+         for r in rows]
+    )
+
+
+def _spec(pmz, rt):
+    return {"id": "s", "precursor_mz": pmz, "rt": rt, "peaks": [("100.0", "1.0")]}
+
+
+def test_ppm_gate_excludes_outside_10ppm():
+    feats = _features([(1, 200.0000, 100.0, 90.0, 110.0)])
+    # 15 ppm away -> excluded; 5 ppm away -> included
+    match_far, unmatched_far = asari_formatter._match_spectra_to_features([_spec(200.0030, 100.0)], feats)
+    match_near, unmatched_near = asari_formatter._match_spectra_to_features([_spec(200.0010, 100.0)], feats)
+    assert match_far == {} and unmatched_far == 1
+    assert set(match_near.keys()) == {1} and unmatched_near == 0
+
+
+def test_rt_bounds_gate_is_strict():
+    feats = _features([(1, 200.0, 100.0, 95.0, 105.0)])
+    # RT inside bounds matches; RT just outside does not
+    inside, u_in = asari_formatter._match_spectra_to_features([_spec(200.0, 105.0)], feats)
+    outside, u_out = asari_formatter._match_spectra_to_features([_spec(200.0, 105.01)], feats)
+    assert set(inside.keys()) == {1} and u_in == 0
+    assert outside == {} and u_out == 1
+
+
+def test_closest_rt_wins_among_candidates():
+    # Two same-m/z features whose windows both contain the spectrum RT.
+    feats = _features([(1, 400.0, 100.0, 90.0, 160.0),
+                       (2, 400.0, 150.0, 90.0, 160.0)])
+    match, _ = asari_formatter._match_spectra_to_features([_spec(400.0, 140.0)], feats)
+    # RT 140 is closer to feature 2's rtime (150) than feature 1's (100).
+    assert set(match.keys()) == {2}
+
+
+def test_mz_breaks_rt_ties():
+    # Two features with identical rtime; RT diff ties -> closest m/z wins.
+    feats = _features([(1, 300.0000, 100.0, 90.0, 110.0),
+                       (2, 300.0010, 100.0, 90.0, 110.0)])
+    match, _ = asari_formatter._match_spectra_to_features([_spec(300.0008, 100.0)], feats)
+    # pmz 300.0008 is closer to feature 2 (300.0010) than feature 1 (300.0000).
+    assert set(match.keys()) == {2}
+
+
+def test_collision_keeps_closest_rt_spectrum():
+    feats = _features([(1, 200.0, 100.0, 80.0, 120.0)])
+    far = _spec(200.0, 110.0)   # rt_diff 10
+    near = _spec(200.0, 98.0)   # rt_diff 2  -> should win
+    match, _ = asari_formatter._match_spectra_to_features([far, near], feats)
+    assert set(match.keys()) == {1}
+    assert match[1][1] is near
+
+
+def test_convert_mgf_monotonic_and_feature_id(tmp_path):
+    feats = _features([(1, 200.0, 100.0, 90.0, 110.0),
+                       (2, 300.0, 200.0, 190.0, 210.0),
+                       (3, 400.0, 300.0, 290.0, 310.0)])  # feature 2 gets no spectrum
+    msp = tmp_path / "in.msp"
+    msp.write_text(
+        "ID: track_a\nPRECURSORMZ: 400.0\nRETENTIONTIME: 300.0\nNum Peaks: 1\n10.0 5.0\n\n"
+        "ID: track_b\nPRECURSORMZ: 200.0\nRETENTIONTIME: 100.0\nNum Peaks: 1\n20.0 6.0\n\n"
+    )
+    out = tmp_path / "out.mgf"
+    written = asari_formatter.convert_mgf(str(msp), str(out), feats)
+    content = out.read_text()
+
+    assert written == 2
+    scans = [int(s) for s in re.findall(r"SCANS=(\d+)", content)]
+    assert scans == [1, 3]                       # sorted ascending, feature 2 absent
+    assert "ASARI_FEATURE_ID=F0" in content      # row ID 1 -> id_number F0
+    assert "ASARI_FEATURE_ID=F2" in content      # row ID 3 -> id_number F2
+
+
+# --------------------------------------------------------------------------
+# Real-data tests against data/Asari_Raw (present locally, untracked).
+# --------------------------------------------------------------------------
+
+def test_feature_csv_headers_and_rows(tmp_path):
+    out = str(tmp_path / "ft.csv")
+    asari_formatter.convert_to_feature_csv(FEATURE_TABLE, out)
+    df = pd.read_csv(out)
+
+    assert list(df.columns[:3]) == ["row ID", "row m/z", "row retention time"]
+
+    peak_cols = [c for c in df.columns if c.endswith(" Peak area")]
+    assert len(peak_cols) == 13
+    assert len(df.columns) == 3 + 13
+
+    # All 41452 features kept, row IDs 1..N, unique, no zero.
+    assert len(df) == 41452
+    assert df["row ID"].min() == 1
+    assert df["row ID"].max() == 41452
+    assert df["row ID"].is_unique
+
+    # Spot-check feature 1 (asari F0): m/z 150.0552, RT 61.27.
+    row1 = df[df["row ID"] == 1].iloc[0]
+    assert abs(row1["row m/z"] - 150.0552) < 1e-3
+    assert abs(row1["row retention time"] - 61.27) < 1e-2
+
+
+def test_mgf_linkage_monotonic_and_known_match(tmp_path):
+    csv_out = str(tmp_path / "ft.csv")
+    mgf_out = str(tmp_path / "specs.mgf")
+    feature_df = asari_formatter.convert_to_feature_csv(FEATURE_TABLE, csv_out)
+    written = asari_formatter.convert_mgf(MSP, mgf_out, feature_df)
+
+    content = open(mgf_out).read()
+    assert written == 1627
+    assert content.count("BEGIN IONS") == 1627
+    assert content.count("END IONS") == 1627
+
+    scans = [int(s) for s in re.findall(r"SCANS=(\d+)", content)]
+    # Every SCANS is a valid row ID, strictly increasing, unique.
+    row_ids = set(pd.read_csv(csv_out)["row ID"].tolist())
+    assert set(scans).issubset(row_ids)
+    assert scans == sorted(scans)
+    assert len(scans) == len(set(scans))
+
+    # Known match: track_150.1280_clus0 (pmz 150.128, RT 147.16) -> row ID 36
+    # (asari F35), whose RT window [141.75, 159.51] contains 147.16. F34's
+    # window ends at 141.75, so it is correctly rejected.
+    first_block = content.split("END IONS")[0]
+    assert "SCANS=36" in first_block
+    assert "TITLE=SCAN=36" in first_block
+    assert "PEPMASS=150.128" in first_block
+    assert "ASARI_FEATURE_ID=F35" in first_block


### PR DESCRIPTION
ASARI previously shared the MZMINE code path, which expects a pre-converted GNPS quant CSV + MGF. Give ASARI its own dispatch branch that consumes raw asari output (aligned feature-table TSV + MS/MS MSP) directly.

The MSP is keyed by mass-track/cluster, not by feature, so asari_formatter matches each spectrum to a feature by precursor m/z (+/- 10 ppm gate) and retention time (must fall within the feature's RT bounds), with the closest RT winning; the same rule resolves collisions. row ID is assigned 1..N by table position and reused as the MGF SCANS so the downstream FBMN join (cluster index == row ID == SCANS) stays coherent. Features without a matched spectrum stay in the quant CSV but get no MGF block; unmatched spectra are dropped.

Includes unit tests (synthetic rule tests + real-data checks against data/Asari_Raw) and a design doc.

GNPS2 Beta test task: https://beta.gnps2.org/status?task=d51966b1014a4f89beeccd4dc1cac360